### PR TITLE
Adding broadcast intent for new photos to Fe-Fi

### DIFF
--- a/src/to/rcpt/fefi/DBAdapter.java
+++ b/src/to/rcpt/fefi/DBAdapter.java
@@ -508,6 +508,7 @@ public class DBAdapter extends SQLiteOpenHelper {
 			augmentLocation(values, 900000);
 			ContentResolver cr = context.getContentResolver();
 			Uri uri = cr.insert(Media.EXTERNAL_CONTENT_URI, values);
+			context.sendBroadcast(new Intent("com.android.camera.NEW_PICTURE", uri));
 			Log.d(TAG, myId + " inserted values to uri " + uri);
 			Vibrator v = (Vibrator)context.getSystemService(Context.VIBRATOR_SERVICE);
 			v.vibrate(300);


### PR DESCRIPTION
Hi!

Thanks for a really excellent photo app!

When the Android camera takes a photo, it sends an (undocumented) broadcast intent, com.android.camera.NEW_PICTURE, which apps can listen on to detect new photos. This one-line patch makes Fe-Fi act likewise, so apps can treat its photos the same way.
